### PR TITLE
Fix ArrayDeque.clone on andriod-8

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/ArrayDeque.java
+++ b/AndroidAsync/src/com/koushikdutta/async/ArrayDeque.java
@@ -798,7 +798,7 @@ public class ArrayDeque<E> extends AbstractCollection<E>
         try {
             @SuppressWarnings("unchecked")
             ArrayDeque<E> result = (ArrayDeque<E>) super.clone();
-            result.elements = Arrays.copyOf(elements, elements.length);
+            System.arraycopy(elements, 0, result.elements, 0, elements.length);
             return result;
 
         } catch (CloneNotSupportedException e) {


### PR DESCRIPTION
`Arrays.copyOf` was introduced in API 9, so the `minSdkVersion`
of 8 is not enough. Substituting for `System.arraycopy` makes a
bit more sense at this point in time.

See https://github.com/koush/AndroidAsync/issues/2#issuecomment-21034492
for discussion.
