### PR TITLE
Use Uri's raw path for creating GET string to avoid removing URL encoding

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
@@ -34,7 +34,7 @@ public class AsyncHttpRequest {
             
             @Override
             public String toString() {
-                String path = AsyncHttpRequest.this.getUri().getPath();
+                String path = AsyncHttpRequest.this.getUri().getRawPath();
                 if (path.length() == 0)
                     path = "/";
                 String query = AsyncHttpRequest.this.getUri().getRawQuery();

--- a/AndroidAsyncTest/src/com/koushikdutta/async/test/HttpClientTests.java
+++ b/AndroidAsyncTest/src/com/koushikdutta/async/test/HttpClientTests.java
@@ -10,12 +10,9 @@ import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.callback.DataCallback;
 import com.koushikdutta.async.future.Future;
 import com.koushikdutta.async.future.FutureCallback;
-import com.koushikdutta.async.http.AsyncHttpClient;
+import com.koushikdutta.async.http.*;
 import com.koushikdutta.async.http.AsyncHttpClient.DownloadCallback;
 import com.koushikdutta.async.http.AsyncHttpClient.StringCallback;
-import com.koushikdutta.async.http.AsyncHttpGet;
-import com.koushikdutta.async.http.AsyncHttpResponse;
-import com.koushikdutta.async.http.ResponseCacheMiddleware;
 import com.koushikdutta.async.http.callback.HttpConnectCallback;
 import com.koushikdutta.async.http.server.AsyncHttpServer;
 import com.koushikdutta.async.http.server.AsyncHttpServerRequest;
@@ -26,6 +23,7 @@ import junit.framework.Assert;
 import junit.framework.TestCase;
 
 import java.io.File;
+import java.net.URI;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
@@ -329,5 +327,11 @@ public class HttpClientTests extends TestCase {
         finally {
             proxyServer.stop();
         }
+    }
+
+    public void testUriPathWithSpaces() throws Exception {
+        AsyncHttpRequest request = new AsyncHttpRequest(URI.create("http://jpkc.seiee.sjtu.edu.cn/ds/ds2/Course%20lecture/chapter%2010.pdf"), AsyncHttpGet.METHOD);
+        String requestLine = request.getRequestLine().toString();
+        assertEquals("GET /ds/ds2/Course%20lecture/chapter%2010.pdf HTTP/1.1", requestLine);
     }
 }


### PR DESCRIPTION
We noticed a bug while using Ion for some file downloading and traced it down to the URI getting decoded in the GET string. You can reproduce the error we saw in Ion using something like the following: 

``` java
Ion.with(context).load("http://jpkc.seiee.sjtu.edu.cn/ds/ds2/Course%20lecture/chapter%2010.pdf")
    .setLogging("IonSample", Log.DEBUG)
    .write(new File(context.getCacheDir(), "foo")).withResponse()
    .setCallback(new FutureCallback<Response<File>>() {
        @Override
        public void onCompleted(Exception e, Response<File> result) {
            if (e != null) {
                logger.writeLine("ERROR " + e.getMessage());
            } else {
                RawHeaders headers = result.getHeaders();
                if (headers.getResponseCode() != 200) {
                    logger.writeLine("Got a bad response code :( " + headers.getResponseCode() + ": " + headers.getResponseMessage());
                } else {
                    logger.writeLine("Success!");
                }
            }
        }
    });
```

AndroidAsync was making GETs with spaces in them which is invalid.
