### PR TITLE
Provide non-generic name for sample app

### DIFF
--- a/AndroidAsyncSample/res/values/strings.xml
+++ b/AndroidAsyncSample/res/values/strings.xml
@@ -3,6 +3,6 @@
     <string name="app_name">AndroidAsyncSample</string>
     <string name="hello_world">Hello world!</string>
     <string name="menu_settings">Settings</string>
-    <string name="title_activity_main">MainActivity</string>
+    <string name="title_activity_main">AndroidAsync Sample</string>
 	<string name="download">Download Images</string>
 </resources>


### PR DESCRIPTION
Give the sample app the name "AndroidAsync Sample" in Android launcher,
instead of the generic name "MainActivity"-
