### PR TITLE
Fixed resource leaks.

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
@@ -12,6 +12,7 @@ import com.koushikdutta.async.future.Cancellable;
 import com.koushikdutta.async.future.Future;
 import com.koushikdutta.async.future.SimpleFuture;
 import com.koushikdutta.async.future.TransformFuture;
+import com.koushikdutta.async.util.StreamUtility;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -299,11 +300,7 @@ public class AsyncServer {
 
                         @Override
                         public void stop() {
-                            try {
-                                wrapper.close();
-                            }
-                            catch (Exception e) {
-                            }
+                            StreamUtility.closeQuietly(wrapper);
                             try {
                                 key.cancel();
                             }
@@ -313,15 +310,7 @@ public class AsyncServer {
                     });
                 }
                 catch (Exception e) {
-                    try {
-                        if (closeableWrapper != null) {
-                            closeableWrapper.close();
-                        } else if (closeableServer != null) {
-                            closeableServer.close();
-                        }
-                    } catch (IOException ioException) {
-                        // http://stackoverflow.com/a/156525/9636
-                    }
+                    StreamUtility.closeQuietly(closeableWrapper, closeableServer);
                     handler.onCompleted(e);
                 }
             }

--- a/AndroidAsync/src/com/koushikdutta/async/http/ResponseCacheMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/ResponseCacheMiddleware.java
@@ -46,6 +46,7 @@ import com.koushikdutta.async.http.libcore.RawHeaders;
 import com.koushikdutta.async.http.libcore.ResponseHeaders;
 import com.koushikdutta.async.http.libcore.ResponseSource;
 import com.koushikdutta.async.http.libcore.StrictLineReader;
+import com.koushikdutta.async.util.StreamUtility;
 
 public class ResponseCacheMiddleware extends SimpleMiddleware {
     private DiskLruCache cache;
@@ -807,15 +808,7 @@ public class ResponseCacheMiddleware extends SimpleMiddleware {
                     localCertificates = null;
 //                }
             } finally {
-                try {
-                    if (reader != null) {
-                        reader.close();
-                    } else if (in != null) {
-                        in.close();
-                    }
-                } catch (IOException e) {
-                    // http://stackoverflow.com/a/156525/9636
-                }
+                StreamUtility.closeQuietly(reader, in);
             }
         }
 

--- a/AndroidAsync/src/com/koushikdutta/async/http/libcore/Streams.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/libcore/Streams.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
 
+import com.koushikdutta.async.util.StreamUtility;
+
 /** From libcore.io.Streams */
 class Streams {
     static String readFully(Reader reader) throws IOException {
@@ -16,11 +18,7 @@ class Streams {
             }
             return writer.toString();
         } finally {
-            try {
-                reader.close();
-            } catch (IOException e) {
-                // http://stackoverflow.com/a/156525/9636
-            }
+            StreamUtility.closeQuietly(reader);
         }
     }
 }

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
@@ -23,6 +23,7 @@ import com.koushikdutta.async.http.WebSocketImpl;
 import com.koushikdutta.async.http.body.AsyncHttpRequestBody;
 import com.koushikdutta.async.http.libcore.RawHeaders;
 import com.koushikdutta.async.http.libcore.RequestHeaders;
+import com.koushikdutta.async.util.StreamUtility;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -343,15 +344,7 @@ public class AsyncHttpServer {
                 }
             } while (entry != null);
         } catch (Exception ex) {
-            try {
-                if (zipInputStream != null) {
-                    zipInputStream.close();
-                } else if (fileInputStream != null) {
-                    fileInputStream.close();
-                }
-            } catch (IOException e) {
-                // http://stackoverflow.com/a/156525/9636
-            }
+            StreamUtility.closeQuietly(zipInputStream, fileInputStream);
         }
         return null;
     }

--- a/AndroidAsync/src/com/koushikdutta/async/util/StreamUtility.java
+++ b/AndroidAsync/src/com/koushikdutta/async/util/StreamUtility.java
@@ -1,6 +1,7 @@
 package com.koushikdutta.async.util;
 
 import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
@@ -72,13 +73,7 @@ public class StreamUtility {
             input = new DataInputStream(new FileInputStream(file));
             input.readFully(buffer);
         } finally {
-            if (input != null) {
-                try {
-                    input.close();
-                } catch (IOException e) {
-                    // http://stackoverflow.com/a/156525/9636
-                }
-            }
+            closeQuietly(input);
         }
         return new String(buffer);
     }
@@ -92,6 +87,19 @@ public class StreamUtility {
     
     public static void writeFile(String file, String string) throws IOException {
         writeFile(new File(file), string);
+    }
+    
+    public static void closeQuietly(Closeable... closeables) {
+        for (Closeable closeable : closeables) {
+            if (closeable != null) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    // http://stackoverflow.com/a/156525/9636
+                }
+                return;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Most of these were pretty trivial, except for getAssetStream. It wasn't ever closing it's ZipFile, which could result in leaked memory. Since it was only being used to read a single entry, I changed it to use a ZipInputStream instead, which the javadocs recommend as being faster anyway.
