### PR TITLE
Use custom exception classes to facilitate better error reporting on the client side

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
@@ -395,7 +395,7 @@ public class AsyncServer {
                 try {
                     final InetAddress[] result = InetAddress.getAllByName(host);
                     if (result == null || result.length == 0)
-                        throw new Exception("no addresses for host");
+                        throw new HostnameResolutionException("no addresses for host");
                     post(new Runnable() {
                         @Override
                         public void run() {

--- a/AndroidAsync/src/com/koushikdutta/async/HostnameResolutionException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/HostnameResolutionException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async;
+
+public class HostnameResolutionException extends Exception {
+    public HostnameResolutionException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
@@ -152,7 +152,7 @@ public class AsyncHttpClient {
     private void executeAffinity(final AsyncHttpRequest request, final int redirectCount, final FutureAsyncHttpResponse cancel, final HttpConnectCallback callback) {
         assert mServer.isAffinityThread();
         if (redirectCount > 15) {
-            reportConnectedCompleted(cancel, new Exception("too many redirects"), null, request, callback);
+            reportConnectedCompleted(cancel, new RedirectLimitExceededException("too many redirects"), null, request, callback);
             return;
         }
         final URI uri = request.getUri();
@@ -677,7 +677,7 @@ public class AsyncHttpClient {
                 }
                 WebSocket ws = WebSocketImpl.finishHandshake(req.getHeaders().getHeaders(), response);
                 if (ws == null) {
-                    if (!ret.setComplete(new Exception("Unable to complete websocket handshake")))
+                    if (!ret.setComplete(new WebSocketHandshakeException("Unable to complete websocket handshake")))
                         return;
                 }
                 else {

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpResponseImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpResponseImpl.java
@@ -92,7 +92,7 @@ abstract class AsyncHttpResponseImpl extends FilteredDataEmitter implements Asyn
         @Override
         public void onCompleted(Exception error) {
             if (error != null && !mCompleted) {
-                report(new Exception("connection closed before response completed."));
+                report(new ConnectionClosedException("connection closed before response completed."));
             }
             else {
                 report(error);

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSocketMiddleware.java
@@ -213,7 +213,7 @@ public class AsyncSocketMiddleware extends SimpleMiddleware {
                     public void onCompleted(Exception ex) {
                         // if it completed, that means that the connection failed
                         if (lastException == null)
-                            lastException = new Exception("Unable to connect to remote address");
+                            lastException = new ConnectionFailedException("Unable to connect to remote address");
                         setComplete(lastException);
                     }
                 });

--- a/AndroidAsync/src/com/koushikdutta/async/http/BodyDecoderException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/BodyDecoderException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http;
+
+public class BodyDecoderException extends Exception {
+    public BodyDecoderException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/ConnectionClosedException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/ConnectionClosedException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http;
+
+public class ConnectionClosedException extends Exception {
+    public ConnectionClosedException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/ConnectionFailedException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/ConnectionFailedException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http;
+
+public class ConnectionFailedException extends Exception {
+    public ConnectionFailedException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/HttpUtil.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/HttpUtil.java
@@ -72,7 +72,7 @@ public class HttpUtil {
         final int contentLength = _contentLength;
         if (-1 != contentLength) {
             if (contentLength < 0) {
-                EndEmitter ender = EndEmitter.create(emitter.getServer(), new Exception("not using chunked encoding, and no content-length found."));
+                EndEmitter ender = EndEmitter.create(emitter.getServer(), new BodyDecoderException("not using chunked encoding, and no content-length found."));
                 ender.setDataEmitter(emitter);
                 emitter = ender;
                 return emitter;

--- a/AndroidAsync/src/com/koushikdutta/async/http/RedirectLimitExceededException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/RedirectLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http;
+
+public class RedirectLimitExceededException extends Exception {
+    public RedirectLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/WebSocketHandshakeException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/WebSocketHandshakeException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http;
+
+public class WebSocketHandshakeException extends Exception {
+    public WebSocketHandshakeException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/ChunkedDataException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/ChunkedDataException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http.filter;
+
+public class ChunkedDataException extends Exception {
+    public ChunkedDataException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/ChunkedInputFilter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/ChunkedInputFilter.java
@@ -22,7 +22,7 @@ public class ChunkedInputFilter extends FilteredDataEmitter {
     
     private boolean checkByte(char b, char value) {
         if (b != value) {
-            report(new Exception(value + " was expeceted, got " + (char)b));
+            report(new ChunkedDataException(value + " was expected, got " + (char)b));
             return false;
         }
         return true;
@@ -39,7 +39,7 @@ public class ChunkedInputFilter extends FilteredDataEmitter {
     @Override
     protected void report(Exception e) {
         if (e == null && mState != State.COMPLETE)
-            e = new Exception("chunked input ended before final chunk");
+            e = new ChunkedDataException("chunked input ended before final chunk");
         super.report(e);
     }
 
@@ -62,7 +62,7 @@ public class ChunkedInputFilter extends FilteredDataEmitter {
                         else if (c >= 'A' && c <= 'F')
                             mChunkLength += (c - 'A' + 10);
                         else {
-                            report(new Exception("invalid chunk length: " + c));
+                            report(new ChunkedDataException("invalid chunk length: " + c));
                             return;
                         }
                     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/ContentLengthFilter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/ContentLengthFilter.java
@@ -12,7 +12,7 @@ public class ContentLengthFilter extends FilteredDataEmitter {
     @Override
     protected void report(Exception e) {
         if (e == null && totalRead != contentLength)
-            e = new Exception("End of data reached before content length was read");
+            e = new PrematureDataEndException("End of data reached before content length was read");
         super.report(e);
     }
 

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/DataRemainingException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/DataRemainingException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http.filter;
+
+public class DataRemainingException extends Exception {
+    public DataRemainingException(String message, Exception cause) {
+        super(message, cause);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/InflaterInputFilter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/InflaterInputFilter.java
@@ -15,7 +15,7 @@ public class InflaterInputFilter extends FilteredDataEmitter {
     @Override
     protected void report(Exception e) {
         if (e != null && mInflater.getRemaining() > 0) {
-            e = new Exception("data still remaining in inflater", e);
+            e = new DataRemainingException("data still remaining in inflater", e);
         }
         super.report(e);
     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/PrematureDataEndException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/PrematureDataEndException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http.filter;
+
+public class PrematureDataEndException extends Exception {
+    public PrematureDataEndException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServerResponseImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServerResponseImpl.java
@@ -227,7 +227,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
             parts = parts[1].split("-");
             try {
                 if (parts.length > 2)
-                    throw new Exception();
+                    throw new MalformedRangeException();
                 if (!TextUtils.isEmpty(parts[0]))
                     start = Integer.parseInt(parts[0]);
                 if (parts.length == 2 && !TextUtils.isEmpty(parts[1]))
@@ -246,7 +246,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
         }
         try {
             if (start != inputStream.skip(start))
-                throw new Exception("skip failed to skip requested amount");
+                throw new StreamSkipException("skip failed to skip requested amount");
             mContentLength = end - start + 1;
             mRawHeaders.set("Content-Length", "" + mContentLength);
             mRawHeaders.set("Accept-Ranges", "bytes");

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/BoundaryEmitter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/BoundaryEmitter.java
@@ -108,7 +108,7 @@ public class BoundaryEmitter extends FilteredDataEmitter {
                     state = -2;
                 }
                 else {
-                    report(new Exception("Invalid multipart/form-data. Expected \r or -"));
+                    report(new MimeEncodingException("Invalid multipart/form-data. Expected \r or -"));
                     return;
                 }
             }
@@ -117,7 +117,7 @@ public class BoundaryEmitter extends FilteredDataEmitter {
                     state = -3;
                 }
                 else {
-                    report(new Exception("Invalid multipart/form-data. Expected -"));
+                    report(new MimeEncodingException("Invalid multipart/form-data. Expected -"));
                     return;
                 }
             }
@@ -133,7 +133,7 @@ public class BoundaryEmitter extends FilteredDataEmitter {
                     onBoundaryEnd();
                 }
                 else {
-                    report(new Exception("Invalid multipart/form-data. Expected \r"));
+                    report(new MimeEncodingException("Invalid multipart/form-data. Expected \r"));
                     return;
                 }
             }
@@ -143,12 +143,12 @@ public class BoundaryEmitter extends FilteredDataEmitter {
                     state = 0;
                 }
                 else {
-                    report(new Exception("Invalid multipart/form-data. Expected \n"));
+                    report(new MimeEncodingException("Invalid multipart/form-data. Expected \n"));
                 }
             }
             else {
                 assert false;
-                report(new Exception("Invalid multipart/form-data. Unknown state?"));
+                report(new MimeEncodingException("Invalid multipart/form-data. Unknown state?"));
             }
         }
 

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/MalformedRangeException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/MalformedRangeException.java
@@ -1,0 +1,4 @@
+package com.koushikdutta.async.http.server;
+
+public class MalformedRangeException extends Exception {
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/MimeEncodingException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/MimeEncodingException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http.server;
+
+public class MimeEncodingException extends Exception {
+    public MimeEncodingException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/StreamSkipException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/StreamSkipException.java
@@ -1,0 +1,7 @@
+package com.koushikdutta.async.http.server;
+
+public class StreamSkipException extends Exception {
+    public StreamSkipException(String message) {
+        super(message);
+    }
+}

--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -121,7 +121,7 @@ class SocketIOConnection {
                 String[] transports = transportsLine.split(",");
                 HashSet<String> set = new HashSet<String>(Arrays.asList(transports));
                 if (!set.contains("websocket"))
-                    throw new Exception("websocket not supported");
+                    throw new SocketIOException("websocket not supported");
 
                 final String sessionUrl = request.getUri().toString() + "websocket/" + session + "/";
 
@@ -399,7 +399,7 @@ class SocketIOConnection {
                             // noop
                             break;
                         default:
-                            throw new Exception("unknown code");
+                            throw new SocketIOException("unknown code");
                     }
                 }
                 catch (Exception ex) {


### PR DESCRIPTION
Use of generic Exception class makes it harder for the client to properly diagnose and report errors to the end user. 
