### PR TITLE
SocketIO: Better handle queries when building the session url

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -1,5 +1,6 @@
 package com.koushikdutta.async.http.socketio;
 
+import android.net.Uri;
 import android.os.Handler;
 import android.text.TextUtils;
 
@@ -123,7 +124,9 @@ class SocketIOConnection {
                 if (!set.contains("websocket"))
                     throw new SocketIOException("websocket not supported");
 
-                final String sessionUrl = request.getUri().toString() + "websocket/" + session + "/";
+                final String sessionUrl = Uri.parse(request.getUri().toString()).buildUpon()
+                		.appendPath("websocket").appendPath(session)
+                		.build().toString();
 
                 setComplete(httpClient.websocket(sessionUrl, null, null));
             }


### PR DESCRIPTION
While using the android-websockets library, I found an issue using query parameters in the SocketIOClient connection url. More information can be found here:

```
https://github.com/koush/android-websockets/pull/30
```

Since that library was ported from AndroidAsync, the changes fix the same issue in this library.
