### PR TITLE
Pass the original exception as the cause when throwing ConnectionClosedException

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpResponseImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpResponseImpl.java
@@ -92,7 +92,7 @@ abstract class AsyncHttpResponseImpl extends FilteredDataEmitter implements Asyn
         @Override
         public void onCompleted(Exception error) {
             if (error != null && !mCompleted) {
-                report(new ConnectionClosedException("connection closed before response completed."));
+                report(new ConnectionClosedException("connection closed before response completed.", error));
             }
             else {
                 report(error);

--- a/AndroidAsync/src/com/koushikdutta/async/http/ConnectionClosedException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/ConnectionClosedException.java
@@ -4,4 +4,8 @@ public class ConnectionClosedException extends Exception {
     public ConnectionClosedException(String message) {
         super(message);
     }
+
+    public ConnectionClosedException(String detailMessage, Throwable throwable) {
+        super(detailMessage, throwable);
+    }
 }


### PR DESCRIPTION
This is especially useful when the underlying error is an SSLException.
