### PR TITLE
Support socketio context info

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIORequest.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIORequest.java
@@ -6,6 +6,12 @@ import android.text.TextUtils;
 import com.koushikdutta.async.http.AsyncHttpPost;
 
 public class SocketIORequest extends AsyncHttpPost {
+    static String socketIOContext = "/socket.io/1/";
+    
+    public String getSocketIOContext() {
+        return socketIOContext;
+    }
+    
     public SocketIORequest(String uri) {
         this(uri, "");
     }
@@ -25,8 +31,14 @@ public class SocketIORequest extends AsyncHttpPost {
     }
 
     public SocketIORequest(String uri, String endpoint, String query) {
-        super(Uri.parse(uri + (query == null ? "" : "?" + query)).buildUpon().encodedPath("/socket.io/1/").build().toString());
+        this(uri,endpoint,query,null);
+    }
+    
+    public SocketIORequest(String uri, String endpoint, String query,String context) {
+        super(Uri.parse(uri + (query == null ? "" : "?" + query)).buildUpon().encodedPath(TextUtils.isEmpty(context) ? socketIOContext
+                : context).build().toString());
         this.endpoint = endpoint;
         this.query = query;
+        SocketIORequest.socketIOContext = context;
     }
 }


### PR DESCRIPTION
if we use such url(compliant with socketio 0.9 spec) http://127.0.0.1/upush/, we must modify default context info to "upush",not "socket.io"
