### PR TITLE
do not count the unknown length in the written count

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/body/MultipartFormDataBody.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/MultipartFormDataBody.java
@@ -155,7 +155,9 @@ public class MultipartFormDataBody extends BoundaryEmitter implements AsyncHttpR
             .add(new ContinuationCallback() {
                 @Override
                 public void onContinue(Continuation continuation, CompletedCallback next) throws Exception {
-                    written += part.length();
+                    long partLength = part.length();
+                    if (partLength >= 0)
+                        written += partLength;
                     part.write(sink, next);
                 }
             })


### PR DESCRIPTION
Even though an unknown size is not recommended/working with multipart encoding
