### PR TITLE
Use the system proxy when it's defined.

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
@@ -278,6 +278,7 @@ public class AsyncHttpClient {
                             newReq.LOGTAG = request.LOGTAG;
                             newReq.proxyHost = request.proxyHost;
                             newReq.proxyPort = request.proxyPort;
+                            newReq.useAndroidProxy = request.useAndroidProxy;
                             copyHeader(request, newReq, "User-Agent");
                             copyHeader(request, newReq, "Range");
                             request.logi("Redirecting");

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
@@ -1,6 +1,8 @@
 package com.koushikdutta.async.http;
 
+import android.annotation.SuppressLint;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 
 import com.koushikdutta.async.AsyncSSLException;
@@ -16,6 +18,10 @@ import org.apache.http.RequestLine;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.params.HttpParams;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -318,21 +324,61 @@ public class AsyncHttpRequest {
 
     String proxyHost;
     int proxyPort = -1;
+    boolean useAndroidProxy = true;
     public void enableProxy(String host, int port) {
         proxyHost = host;
         proxyPort = port;
+        useAndroidProxy = proxyPort == 0;
+    }
+
+    public void enableSystemProxy(boolean enable) {
+        useAndroidProxy = enable;
     }
 
     public void disableProxy() {
         proxyHost = null;
         proxyPort = -1;
+        useAndroidProxy = false;
+    }
+
+    @SuppressLint("NewApi")
+    private void setupAndroidProxy() {
+        List<Proxy> proxies = ProxySelector.getDefault().select(URI.create(getUri().toString()));
+        if (proxies.isEmpty()) {
+            disableProxy();
+        } else {
+            Proxy proxy = proxies.get(0);
+            if (proxy.type() == Proxy.Type.DIRECT) {
+                disableProxy();
+            } else if (proxy.type() == Proxy.Type.HTTP && proxy.address() instanceof InetSocketAddress) {
+                InetSocketAddress proxyAddress = (InetSocketAddress) proxy.address();
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+                    proxyHost = proxyAddress.getHostString();
+                else {
+                    InetAddress address = proxyAddress.getAddress();
+                    if (address!=null)
+                        proxyHost = address.getHostAddress();
+                    else
+                        proxyHost = proxyAddress.getHostName();
+                }
+                proxyPort = proxyAddress.getPort();
+            }
+        }
     }
 
     public String getProxyHost() {
+        if (useAndroidProxy) {
+            setupAndroidProxy();
+            useAndroidProxy = false;
+        }
         return proxyHost;
     }
 
     public int getProxyPort() {
+        if (useAndroidProxy) {
+            setupAndroidProxy();
+            useAndroidProxy = false;
+        }
         return proxyPort;
     }
 


### PR DESCRIPTION
The default HttpUrlConnection does that, as well as okhttp.

This should only work on API v12 and above. Before that the system proxy had to be read manually by the UrlConnection user.
