### PR TITLE
Crash fix for a case where the EndCallback is not set and used

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/BufferedDataEmitter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/BufferedDataEmitter.java
@@ -32,7 +32,7 @@ public class BufferedDataEmitter implements DataEmitter, DataCallback {
         if (mDataCallback != null && !mPaused && mBuffers.remaining() > 0)
             mDataCallback.onDataAvailable(this, mBuffers);
         
-        if (mEnded && mBuffers.remaining() == 0)
+        if (mEnded && mBuffers.remaining() == 0 && mEndCallback != null)
             mEndCallback.onCompleted(mEndException);
     }
     


### PR DESCRIPTION
Here is the stack trace

``````
java.lang.RuntimeException: java.lang.NullPointerException
       at com.koushikdutta.async.AsyncServer.runLoop(SourceFile:789)
       at com.koushikdutta.async.AsyncServer.run(SourceFile:603)
       at com.koushikdutta.async.AsyncServer.access$700(SourceFile:37)
       at com.koushikdutta.async.AsyncServer$13.run(SourceFile:552)
Caused by: java.lang.NullPointerException
       at com.koushikdutta.async.BufferedDataEmitter.onDataAvailable(SourceFile:36)
       at com.koushikdutta.async.AsyncSSLSocketWrapper.handleHandshakeStatus(SourceFile:251)
       at com.koushikdutta.async.AsyncSSLSocketWrapper.write(SourceFile:366)
       at com.koushikdutta.async.AsyncSSLSocketWrapper.handleHandshakeStatus(SourceFile:247)
       at com.koushikdutta.async.AsyncSSLSocketWrapper.handshake(SourceFile:112)
       at com.koushikdutta.async.http.AsyncSSLSocketMiddleware.tryHandshake(SourceFile:82)
       at com.koushikdutta.async.http.AsyncSSLSocketMiddleware$2.onConnectCompleted(SourceFile:95)
       at com.koushikdutta.async.AsyncServer.runLoop(SourceFile:786)
       at com.koushikdutta.async.AsyncServer.run(SourceFile:603)
       at com.koushikdutta.async.AsyncServer.access$700(SourceFile:37)
       at com.koushikdutta.async.AsyncServer$13.run(SourceFile:552)```
``````
