### PR TITLE
Fix a rare NPE crash in Android 2.x

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
@@ -727,6 +727,9 @@ public class AsyncServer {
                 }
             }
         }
+        catch (NullPointerException e) {
+            throw new AsyncSelectorException(e);
+        }
         catch (IOException e) {
             throw new AsyncSelectorException(e);
         }


### PR DESCRIPTION
Here is the stack trace

```
java.lang.NullPointerException
       at org.apache.harmony.nio.internal.FileChannelImpl.read(FileChannelImpl.java:280)
       at org.apache.harmony.nio.internal.PipeImpl$PipeSourceChannel.read(PipeImpl.java:84)
       at org.apache.harmony.nio.internal.SelectorImpl.processSelectResult(SelectorImpl.java:301)
       at org.apache.harmony.nio.internal.SelectorImpl.selectInternal(SelectorImpl.java:228)
       at org.apache.harmony.nio.internal.SelectorImpl.selectNow(SelectorImpl.java:191)
       at com.koushikdutta.async.SelectorWrapper.selectNow(SourceFile:26)
       at com.koushikdutta.async.AsyncServer.runLoop(SourceFile:705)
       at com.koushikdutta.async.AsyncServer.run(SourceFile:608)
       at com.koushikdutta.async.AsyncServer.access$700(SourceFile:37)
       at com.koushikdutta.async.AsyncServer$13.run(SourceFile:557)
```
