### PR TITLE
Expose the initial HTTP request in WebSocket API

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
@@ -285,7 +285,7 @@ public class AsyncHttpServer {
     }
 
     public static interface WebSocketRequestCallback {
-        public void onConnected(WebSocket webSocket, RequestHeaders headers);
+        public void onConnected(WebSocket webSocket, AsyncHttpServerRequest request);
     }
 
     public void websocket(String regex, final WebSocketRequestCallback callback) {
@@ -318,7 +318,7 @@ public class AsyncHttpServer {
                     response.end();
                     return;
                 }
-                callback.onConnected(new WebSocketImpl(request, response), request.getHeaders());
+                callback.onConnected(new WebSocketImpl(request, response), request);
             }
         });
     }

--- a/AndroidAsync/test/src/com/koushikdutta/async/test/WebSocketTests.java
+++ b/AndroidAsync/test/src/com/koushikdutta/async/test/WebSocketTests.java
@@ -9,6 +9,7 @@ import com.koushikdutta.async.http.WebSocket.StringCallback;
 import com.koushikdutta.async.http.libcore.RequestHeaders;
 import com.koushikdutta.async.http.server.AsyncHttpServer;
 import com.koushikdutta.async.http.server.AsyncHttpServer.WebSocketRequestCallback;
+import com.koushikdutta.async.http.server.AsyncHttpServerRequest;
 
 import junit.framework.TestCase;
 
@@ -34,7 +35,7 @@ public class WebSocketTests extends TestCase {
     
         httpServer.websocket("/ws", new WebSocketRequestCallback() {
             @Override
-            public void onConnected(final WebSocket webSocket, RequestHeaders headers) {
+            public void onConnected(final WebSocket webSocket, AsyncHttpServerRequest request) {
                 webSocket.setStringCallback(new StringCallback() {
                     @Override
                     public void onStringAvailable(String s) {

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ server.listen(5000);
 ```java
 server.websocket("/live", new WebSocketRequestCallback() {
     @Override
-    public void onConnected(final WebSocket webSocket, RequestHeaders headers) {
+    public void onConnected(final WebSocket webSocket, AsyncHttpServerRequest request) {
         _sockets.add(webSocket);
         
         //Use this to clean up any references to your websocket


### PR DESCRIPTION
See discussion in #232 

Reverts previous attempt at solving the issue and introduce a new getInitialHttpRequest method

The previous method works fine for my purposes, but this feels like it results in a better flow (processing can be done after routing to the appropriate callback).

Feel free to pull it or drop it ;)
