### PR TITLE
more debug about invalid URI not recognized by any middleware

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
@@ -420,6 +420,7 @@ public class AsyncHttpClient {
         // set up the system default proxy and connect
         setupAndroidProxy(request);
 
+        final Exception unsupportedURI;
         synchronized (mMiddleware) {
             for (AsyncHttpClientMiddleware middleware: mMiddleware) {
                 Cancellable socketCancellable = middleware.getSocket(data);
@@ -429,8 +430,9 @@ public class AsyncHttpClient {
                     return;
                 }
             }
+            unsupportedURI = new IllegalArgumentException("invalid uri="+uri+" middlewares="+mMiddleware);
         }
-        reportConnectedCompleted(cancel, new IllegalArgumentException("invalid uri"), null, request, callback);
+        reportConnectedCompleted(cancel, unsupportedURI, null, request, callback);
     }
 
     public static abstract class RequestCallbackBase<T> implements RequestCallback<T> {


### PR DESCRIPTION
I get this stack trace, andI have no idea why this perfectly fine URL is not be supported.

``````
com.levelup.http.twitter.TwitterException: #4000 req:HttpTwitterRequest{42767a98 https://api.twitter.com/1.1/direct_messages/sent.json?include_entities=true&count=200&since_id=511740886355824639 } 
       at com.levelup.http.twitter.TwitterException$Builder.build(SourceFile:82)
       at com.levelup.http.twitter.TwitterException$Builder.build(SourceFile:59)
       at com.levelup.http.ion.HttpEngineIon.queryResponse(SourceFile:177)
       at com.levelup.http.ion.HttpEngineIon.queryResponse(SourceFile:62)
       at com.levelup.http.AbstractHttpEngine.call(SourceFile:167)
       at com.plume.twitter.TwitterClient.doTwitterRequest(SourceFile:1175)
       at com.plume.twitter.TwitterClient.getSentDirectMessages(SourceFile:824)
       at com.levelup.socialapi.twitter.UpdateTwitterDM$2.loadPage(SourceFile:29)
       at com.levelup.socialapi.twitter.UpdateTwitterDM$2.loadPage(SourceFile:26)
       at com.levelup.socialapi.AbstractPageLoader.loadPage(SourceFile:19)
       at com.levelup.socialapi.twitter.UpdateThreadTwitter.runUpdate(SourceFile:58)
       at com.levelup.socialapi.UpdateThread.call(SourceFile:67)
       at com.levelup.socialapi.UpdateThread.call(SourceFile:9)
       at java.util.concurrent.FutureTask$Sync.innerRun(FutureTask.java:305)
       at java.util.concurrent.FutureTask.run(FutureTask.java:137)
       at com.levelup.http.async.AsyncTask.run(SourceFile:92)
       at com.levelup.socialapi.UpdateThreadFuture.run(SourceFile:30)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1076)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:569)
       at java.lang.Thread.run(Thread.java:856)
Caused by: java.lang.IllegalArgumentException: invalid uri
       at com.koushikdutta.async.http.AsyncHttpClient.executeAffinity(SourceFile:433)
       at com.koushikdutta.async.http.AsyncHttpClient.execute(SourceFile:182)
       at com.koushikdutta.async.http.AsyncHttpClient.access$600(SourceFile:51)
       at com.koushikdutta.async.http.AsyncHttpClient$3$1.setDataEmitter(SourceFile:330)
       at com.koushikdutta.async.http.AsyncHttpResponseImpl$4.onStringAvailable(SourceFile:136)
       at com.koushikdutta.async.LineEmitter.onDataAvailable(SourceFile:27)
       at com.koushikdutta.async.Util.emitAllData(SourceFile:20)
       at com.koushikdutta.async.AsyncSSLSocketWrapper$4.onDataAvailable(SourceFile:198)
       at com.koushikdutta.async.BufferedDataEmitter.onDataAvailable(SourceFile:33)
       at com.koushikdutta.async.BufferedDataEmitter.onDataAvailable(SourceFile:61)
       at com.koushikdutta.async.Util.emitAllData(SourceFile:20)
       at com.koushikdutta.async.AsyncNetworkSocket.onReadable(SourceFile:175)
       at com.koushikdutta.async.AsyncServer.runLoop(SourceFile:766)
       at com.koushikdutta.async.AsyncServer.run(SourceFile:608)
       at com.koushikdutta.async.AsyncServer.access$700(SourceFile:37)
       at com.koushikdutta.async.AsyncServer$13.run(SourceFile:557)```
``````
