### PR TITLE
asyncHttpServer.directory fix. replaceAll replaces the entire url pattern.

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
@@ -332,7 +332,7 @@ public class AsyncHttpServer {
     }
 
     public static android.util.Pair<Integer, InputStream> getAssetStream(final Context context, String asset) {
-        AssetManager am = context.getAssets();
+        AssetManager am = context.getResources().getAssets();
         try {
             InputStream is = am.open(asset);
             return new android.util.Pair<Integer, InputStream>(is.available(), is);
@@ -373,12 +373,16 @@ public class AsyncHttpServer {
         return null;
     }
 
+    private String replacePrefix(Matcher m) {
+        return m.group(0).substring(m.end(1));
+    }
+
     public void directory(Context context, String regex, final String assetPath) {
         final Context _context = context.getApplicationContext();
         addAction(AsyncHttpGet.METHOD, regex, new HttpServerRequestCallback() {
             @Override
             public void onRequest(AsyncHttpServerRequest request, final AsyncHttpServerResponse response) {
-                String path = request.getMatcher().replaceAll("");
+                String path = replacePrefix(request.getMatcher());
                 android.util.Pair<Integer, InputStream> pair = getAssetStream(_context, assetPath + path);
                 final InputStream is = pair.second;
                 response.getHeaders().getHeaders().set("Content-Length", String.valueOf(pair.first));
@@ -401,7 +405,7 @@ public class AsyncHttpServer {
         addAction(AsyncHttpHead.METHOD, regex, new HttpServerRequestCallback() {
             @Override
             public void onRequest(AsyncHttpServerRequest request, final AsyncHttpServerResponse response) {
-                String path = request.getMatcher().replaceAll("");
+                String path = replacePrefix(request.getMatcher());
                 android.util.Pair<Integer, InputStream> pair = getAssetStream(_context, assetPath + path);
                 final InputStream is = pair.second;
                 StreamUtility.closeQuietly(is);
@@ -428,7 +432,7 @@ public class AsyncHttpServer {
         addAction("GET", regex, new HttpServerRequestCallback() {
             @Override
             public void onRequest(AsyncHttpServerRequest request, final AsyncHttpServerResponse response) {
-                String path = request.getMatcher().replaceAll("");
+                String path = replacePrefix(request.getMatcher());
                 File file = new File(directory, path);
                 
                 if (file.isDirectory() && list) {


### PR DESCRIPTION
Currently the code in asyncHttpServer works as follows.
1. It uses pattern.matches() to verify whether a match has been found in the URL. This needs to match the entire string else the match doesn't succeed.
2. To extract the path, the directory function replaces the entire match with "".

So for example, if I need to match URLs with the pattern "/files/.*", the match succeeds, but the replaceAll("") converts the entire match to "". Thus for "/files/myfile", the path ends up as "" and doesn't work. If I simply use "/files/", the pattern.matches() fails since it'd doesn't match the entire string.

I have modified the code to do the following - Pattern matches the entire string but detects the path as the substring after the first group.

So "(/files/).*" matches "/files/myfile", but replaces it with "myfile".

Please let me know if this seems right. Thanks a lot for the great library.
