### PR TITLE
If the emitter is closed while processing data, then just eat the remaining data.

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/Util.java
+++ b/AndroidAsync/src/com/koushikdutta/async/Util.java
@@ -34,7 +34,12 @@ public class Util {
                 throw new RuntimeException("mDataHandler failed to consume data, yet remains the mDataHandler.");
             }
         }
-        if (list.remaining() != 0 && !emitter.isPaused()) {
+        if (list.remaining() != 0 && handler == null) {
+            // The emitter was closed or cancelled while processing data.  Lets just eat the remaining.
+            System.out.println("emitter: " + emitter);
+            list.recycle();
+        }
+        else if (list.remaining() != 0 && !emitter.isPaused()) {
             // not all the data was consumed...
             // call byteBufferList.recycle() or read all the data to prevent this assertion.
             // this is nice to have, as it identifies protocol or parsing errors.


### PR DESCRIPTION
Don't throw an exception, as this is a valid case.  This can happen if a request is cancelled while it's still processing the data.

Code is from 11/11/2014.  The pair of callstacks that lead me to this:

E/VIMEO   ( 5941): Error getting video: 
E/VIMEO   ( 5941): java.util.concurrent.CancellationException
E/VIMEO   ( 5941):  at com.koushikdutta.async.future.SimpleFuture.cancelInternal(SimpleFuture.java:39)
E/VIMEO   ( 5941):  at com.koushikdutta.async.future.SimpleFuture.cancel(SimpleFuture.java:54)
E/VIMEO   ( 5941):  at com.koushikdutta.ion.Ion.cancelAll(Ion.java:351)
E/VIMEO   ( 5941):  at com.koushikdutta.ion.Ion.cancelAll(Ion.java:382)
E/VIMEO   ( 5941):  at tv.ouya.console.launcher.store.DetailsActivity.onPause(DetailsActivity.java:568)
E/VIMEO   ( 5941):  at android.app.Activity.performPause(Activity.java:5161)
E/VIMEO   ( 5941):  at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1225)
E/VIMEO   ( 5941):  at android.app.ActivityThread.performPauseActivity(ActivityThread.java:2825)
E/VIMEO   ( 5941):  at android.app.ActivityThread.performPauseActivity(ActivityThread.java:2794)
E/VIMEO   ( 5941):  at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:2772)
E/VIMEO   ( 5941):  at android.app.ActivityThread.access$800(ActivityThread.java:130)
E/VIMEO   ( 5941):  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1212)
E/VIMEO   ( 5941):  at android.os.Handler.dispatchMessage(Handler.java:99)
E/VIMEO   ( 5941):  at android.os.Looper.loop(Looper.java:137)
E/VIMEO   ( 5941):  at android.app.ActivityThread.main(ActivityThread.java:4745)
E/VIMEO   ( 5941):  at java.lang.reflect.Method.invokeNative(Native Method)
E/VIMEO   ( 5941):  at java.lang.reflect.Method.invoke(Method.java:511)
E/VIMEO   ( 5941):  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
E/VIMEO   ( 5941):  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
E/VIMEO   ( 5941):  at dalvik.system.NativeStart.main(Native Method)

-- and --

E/AndroidRuntime( 5941): FATAL EXCEPTION: ion-ion
E/AndroidRuntime( 5941): java.lang.RuntimeException: Not all data was consumed by Util.emitAllData
E/AndroidRuntime( 5941):    at com.koushikdutta.async.Util.emitAllData(Util.java:45)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.http.ResponseCacheMiddleware$CachedBodyEmitter.spewInternal(ResponseCacheMiddleware.java:413)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.http.ResponseCacheMiddleware$1.run(ResponseCacheMiddleware.java:167)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.AsyncServer.lockAndRunQueue(AsyncServer.java:708)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.AsyncServer.runLoop(AsyncServer.java:725)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.AsyncServer.run(AsyncServer.java:626)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.AsyncServer.access$700(AsyncServer.java:41)
E/AndroidRuntime( 5941):    at com.koushikdutta.async.AsyncServer$13.run(AsyncServer.java:568)
