### PR TITLE
Update WebSocketImpl.java

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/WebSocketImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/WebSocketImpl.java
@@ -39,7 +39,7 @@ public class WebSocketImpl implements WebSocket {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
             md.update(text.getBytes("iso-8859-1"), 0, text.length());
             byte[] sha1hash = md.digest();
-            return Base64.encodeToString(sha1hash, 0);
+            return Base64.encodeToString(sha1hash, Base64.NO_WRAP);
         }
         catch (Exception ex) {
             return null;


### PR DESCRIPTION
The Base64 add a newline character to the encoded string. With the extra newline mark the header will be invalid and it cause "Bad request".
