### PR TITLE
Catch Throwable from socket.connect().

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncServer.java
@@ -361,11 +361,11 @@ public class AsyncServer {
                     ckey.attach(cancel);
                     socket.connect(address);
                 }
-                catch (IOException e) {
+                catch (Throwable e) {
                     if (ckey != null)
                         ckey.cancel();
                     StreamUtility.closeQuietly(socket);
-                    cancel.setComplete(e);
+                    cancel.setComplete(new RuntimeException(e));
                 }
             }
         });


### PR DESCRIPTION
Due to framework bug nio socket connect method may throw AssertionError if socket is already closed on other thread, it would crash the whole app, and should just report an error for this request.
Catching any Throwwable is the easiest work around this problem.
Fixes #282
