### PR TITLE
Some proxies may insert some Headers in their CONNECT response

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
@@ -124,13 +124,13 @@ public class AsyncSSLSocketMiddleware extends AsyncSocketMiddleware {
                                     }
                                 }
                                 else {
-                                    socket.setDataCallback(null);
-                                    socket.setEndCallback(null);
                                     if (TextUtils.isEmpty(s.trim())) {
+                                        socket.setDataCallback(null);
+                                        socket.setEndCallback(null);
                                         tryHandshake(socket, data, uri, port, callback);
                                     }
-                                    else {
-                                        callback.onConnectCompleted(new IOException("unknown second status line"), socket);
+                                    else if (!s.contains(":")) {
+                                        callback.onConnectCompleted(new IOException("unknown header line "+s), socket);
                                     }
                                 }
                             }


### PR DESCRIPTION
Like `Proxy-Connection: Keep-Alive` or `Via: 1.2.3.4.5`

Without this patch the HTTP response is refused and the connection closed.
