### PR TITLE
fix issue 461

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
@@ -104,7 +104,7 @@ public class ResponseCacheMiddleware extends SimpleMiddleware {
             return null;
         }
 
-        String key = FileCache.toKeyString(data.request.getUri());
+        String key = cache.toKeyString(data.request.getUri());
         FileInputStream[] snapshot = null;
         long contentLength;
         Entry entry;
@@ -267,7 +267,7 @@ public class ResponseCacheMiddleware extends SimpleMiddleware {
             return;
         }
 
-        String key = FileCache.toKeyString(data.request.getUri());
+        String key = cache.toKeyString(data.request.getUri());
         RawHeaders varyHeaders = requestHeaders.getHeaders().getAll(networkResponse.getVaryFields());
         Entry entry = new Entry(data.request.getUri(), varyHeaders, data.request, networkResponse.getHeaders());
         BodyCacher cacher = new BodyCacher();


### PR DESCRIPTION
I have managed to apply workaround to issue #461 mentioned here: https://github.com/koush/ion/issues/461 based on this commit https://github.com/candrews/HttpResponseCache/commit/a93c92d1d8b87778ac7bb2fa2fe2759e7ca06219
I use local copy of MessageDigest in com.koushikdutta.async.util.FileCache instead of getting instance of MessageDigest each time. It prevents from occuring java.util.ConcurrentModificationException at com.koushikdutta.async.util.FileCache.toKeyString().

All tests pass except com.koushikdutta.async.test.ConscryptTests#testConscryptSSLEngineNPNHandshakeBug - thrown exception:

java.lang.reflect.InvocationTargetException
at com.koushikdutta.async.test.ConscryptTests.testConscryptSSLEngineNPNHandshakeBug(ConscryptTests.java:111)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:191)
at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:176)
at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:555)
at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1853)
Caused by: java.lang.SecurityException
at com.google.android.gms.common.security.ProviderInstallerImpl.insertProvider(SourceFile:59)
... 15 more

It doesn't looks like it's caused by changes introduced by me (but, of course, I may be wrong).