### PR TITLE
If wifi isn't connected skips the setupAndroidProxy() method (issue 289)

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/util/ContextProvider.java
+++ b/AndroidAsync/src/com/koushikdutta/async/util/ContextProvider.java
@@ -1,0 +1,28 @@
+package com.koushikdutta.async.util;
+
+import android.content.Context;
+
+/**
+ * Provides a {@link android.content.Context} to check wifi status.
+ */
+public class ContextProvider {
+
+    private static Context context;
+
+    private ContextProvider() {
+    }
+
+    public static void createContextProvider(Context context) {
+        if (ContextProvider.context == null) {
+            ContextProvider.context = context;
+        }
+    }
+
+    public static Context getContext() throws NoContextException {
+        if (ContextProvider.context == null) {
+            throw new NoContextException();
+        }
+        return ContextProvider.context;
+    }
+
+}

--- a/AndroidAsync/src/com/koushikdutta/async/util/NoContextException.java
+++ b/AndroidAsync/src/com/koushikdutta/async/util/NoContextException.java
@@ -1,0 +1,8 @@
+package com.koushikdutta.async.util;
+
+/**
+ * Handles the scenario where no {@link android.content.Context} is provided.
+ * Created by jmougan on 19/03/2015.
+ */
+public class NoContextException extends Exception {
+}


### PR DESCRIPTION
This is a possible fix to [issue 289](https://github.com/koush/AndroidAsync/issues/289). If the user application wants to provide a Context, the library can check wifi status, and skip the proxy setup if wifi isn't enabled. Otherwise, the library will behave exactly as it does right now.