### PR TITLE
Fix: avoid unrecgonized request in other locales

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
@@ -15,6 +15,7 @@ import org.apache.http.message.BasicHeader;
 import org.apache.http.params.HttpParams;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class AsyncHttpRequest {
@@ -44,7 +45,7 @@ public class AsyncHttpRequest {
                 if (query != null && query.length() != 0) {
                     path += "?" + query;
                 }
-                return String.format("%s %s HTTP/1.1", mMethod, path);
+                return String.format(Locale.US, "%s %s HTTP/1.1", mMethod, path);
             }
         };
     }
@@ -68,7 +69,7 @@ public class AsyncHttpRequest {
 
             @Override
             public String toString() {
-                return String.format("%s %s HTTP/1.1", mMethod, AsyncHttpRequest.this.getUri());
+                return String.format(Locale.US, "%s %s HTTP/1.1", mMethod, AsyncHttpRequest.this.getUri());
             }
         };
     }
@@ -348,7 +349,7 @@ public class AsyncHttpRequest {
             elapsed = System.currentTimeMillis() - executionTime;
         else
             elapsed = 0;
-        return String.format("(%d ms) %s: %s", elapsed, getUri(), message);
+        return String.format(Locale.US, "(%d ms) %s: %s", elapsed, getUri(), message);
     }
     public void logi(String message) {
         if (LOGTAG == null)

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
@@ -14,6 +14,7 @@ import com.koushikdutta.async.callback.ConnectCallback;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -102,7 +103,7 @@ public class AsyncSSLSocketMiddleware extends AsyncSocketMiddleware {
                 // this SSL connection is proxied, must issue a CONNECT request to the proxy server
                 // http://stackoverflow.com/a/6594880/704837
                 // some proxies also require 'Host' header, it should be safe to provide it every time
-                String connect = String.format("CONNECT %s:%s HTTP/1.1\r\nHost: %s\r\n\r\n", uri.getHost(), port, uri.getHost());
+                String connect = String.format(Locale.US, "CONNECT %s:%s HTTP/1.1\r\nHost: %s\r\n\r\n", uri.getHost(), port, uri.getHost());
                 data.request.logv("Proxying: " + connect);
                 Util.writeAll(socket, connect.getBytes(), new CompletedCallback() {
                     @Override

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSocketMiddleware.java
@@ -18,6 +18,7 @@ import com.koushikdutta.async.future.TransformFuture;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Hashtable;
+import java.util.Locale;
 
 public class AsyncSocketMiddleware extends SimpleMiddleware {
     String scheme;
@@ -216,7 +217,7 @@ public class AsyncSocketMiddleware extends SimpleMiddleware {
                 });
 
                 for (final InetAddress address: result) {
-                    final String inetSockAddress = String.format("%s:%s", address, port);
+                    final String inetSockAddress = String.format(Locale.US, "%s:%s", address, port);
                     keepTrying.add(new ContinuationCallback() {
                         @Override
                         public void onContinue(Continuation continuation, final CompletedCallback next) throws Exception {

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/Part.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/Part.java
@@ -9,6 +9,7 @@ import org.apache.http.NameValuePair;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 
 public class Part {
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
@@ -28,10 +29,10 @@ public class Part {
     public Part(String name, long length, List<NameValuePair> contentDisposition) {
         this.length = length;
         mHeaders = new Headers();
-        StringBuilder builder = new StringBuilder(String.format("form-data; name=\"%s\"", name));
+        StringBuilder builder = new StringBuilder(String.format(Locale.US, "form-data; name=\"%s\"", name));
         if (contentDisposition != null) {
             for (NameValuePair pair: contentDisposition) {
-                builder.append(String.format("; %s=\"%s\"", pair.getName(), pair.getValue()));
+                builder.append(String.format(Locale.US, "; %s=\"%s\"", pair.getName(), pair.getValue()));
             }
         }
         mHeaders.set(CONTENT_DISPOSITION, builder.toString());

--- a/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
@@ -43,6 +43,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.net.ssl.SSLEngine;
@@ -226,7 +227,7 @@ public class ResponseCacheMiddleware extends SimpleMiddleware {
         CacheData cacheData = data.state.get("cache-data");
         RawHeaders rh = RawHeaders.fromMultimap(data.response.headers().getMultiMap());
         rh.removeAll("Content-Length");
-        rh.setStatusLine(String.format("%s %s %s", data.response.protocol(), data.response.code(), data.response.message()));
+        rh.setStatusLine(String.format(Locale.US, "%s %s %s", data.response.protocol(), data.response.code(), data.response.message()));
         ResponseHeaders networkResponse = new ResponseHeaders(data.request.getUri(), rh);
         data.state.put("response-headers", networkResponse);
         if (cacheData != null) {

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/GZIPInputFilter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/GZIPInputFilter.java
@@ -9,6 +9,7 @@ import com.koushikdutta.async.callback.DataCallback;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Locale;
 import java.util.zip.CRC32;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
@@ -55,7 +56,7 @@ public class GZIPInputFilter extends InflaterInputFilter {
                 public void parsed(byte[] header) {
                     short magic = peekShort(header, 0, ByteOrder.LITTLE_ENDIAN);
                     if (magic != (short) GZIPInputStream.GZIP_MAGIC) {
-                        report(new IOException(String.format("unknown format (magic number %x)", magic)));
+                        report(new IOException(String.format(Locale.US, "unknown format (magic number %x)", magic)));
                         emitter.setDataCallback(new NullDataCallback());
                         return;
                     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServerResponseImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServerResponseImpl.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Locale;
 
 public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
     private Headers mRawHeaders = new Headers();
@@ -96,7 +97,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
             isChunked = false;
         }
 
-        String statusLine = String.format("HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
+        String statusLine = String.format(Locale.US, "HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
         String rh = mRawHeaders.toPrefixString(statusLine);
 
         Util.writeAll(mSocket, rh.getBytes(), new CompletedCallback() {
@@ -266,7 +267,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
                     end = totalLength - 1;
 
                 code(206);
-                getHeaders().set("Content-Range", String.format("bytes %d-%d/%d", start, end, totalLength));
+                getHeaders().set("Content-Range", String.format(Locale.US, "bytes %d-%d/%d", start, end, totalLength));
             }
             catch (Exception e) {
                 code(416);
@@ -388,7 +389,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
     public String toString() {
         if (mRawHeaders == null)
             return super.toString();
-        String statusLine = String.format("HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
+        String statusLine = String.format(Locale.US, "HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
         return mRawHeaders.toPrefixString(statusLine);
     }
 }

--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Locale;
 
 /**
  * Created by koush on 7/1/13.
@@ -54,13 +55,13 @@ class SocketIOConnection {
             ack =  id + "+";
             acknowledges.put(id, acknowledge);
         }
-        transport.send(String.format("%d:%s:%s:%s", type, ack, client.endpoint, message));
+        transport.send(String.format(Locale.US, "%d:%s:%s:%s", type, ack, client.endpoint, message));
     }
 
     public void connect(SocketIOClient client) {
         if (!clients.contains(client))
             clients.add(client);
-        transport.send(String.format("1::%s", client.endpoint));
+        transport.send(String.format(Locale.US, "1::%s", client.endpoint));
     }
 
     public void disconnect(SocketIOClient client) {
@@ -79,7 +80,7 @@ class SocketIOConnection {
         }
 
         if (needsEndpointDisconnect && transport != null)
-            transport.send(String.format("0::%s", client.endpoint));
+            transport.send(String.format(Locale.US, "0::%s", client.endpoint));
 
         // and see if we can disconnect the socket completely
         if (clients.size() > 0 || transport == null)
@@ -357,7 +358,7 @@ class SocketIOConnection {
                     });
                     return;
                 }
-                transport.send(String.format("6:::%s%s", messageId, data));
+                transport.send(String.format(Locale.US, "6:::%s%s", messageId, data));
             }
         };
     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/ByteString.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/ByteString.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Field;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * An immutable sequence of bytes.
@@ -253,11 +254,11 @@ final class ByteString implements Serializable {
     }
 
     if (data.length <= 16) {
-      return String.format("ByteString[size=%s data=%s]", data.length, hex());
+      return String.format(Locale.US, "ByteString[size=%s data=%s]", data.length, hex());
     }
 
     try {
-      return String.format("ByteString[size=%s md5=%s]", data.length,
+      return String.format(Locale.US, "ByteString[size=%s md5=%s]", data.length,
           ByteString.of(MessageDigest.getInstance("MD5").digest(data)).hex());
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError();

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/Header.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/Header.java
@@ -1,6 +1,8 @@
 package com.koushikdutta.async.http.spdy;
 
 
+import java.util.Locale;
+
 /** HTTP header: the name is an ASCII string, but the value can be UTF-8. */
 final class Header {
   // Special header names defined in the SPDY and HTTP/2 specs.
@@ -50,6 +52,6 @@ final class Header {
   }
 
   @Override public String toString() {
-    return String.format("%s: %s", name.utf8(), value.utf8());
+    return String.format(Locale.US, "%s: %s", name.utf8(), value.utf8());
   }
 }

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/Spdy3.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/Spdy3.java
@@ -30,6 +30,7 @@ import java.net.ProtocolException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.Deflater;
 
 
@@ -351,7 +352,7 @@ final class Spdy3 implements Variant {
         }
 
         private static IOException ioException(String message, Object... args) throws IOException {
-            throw new IOException(String.format(message, args));
+            throw new IOException(String.format(Locale.US, message, args));
         }
     }
 

--- a/AndroidAsync/src/com/koushikdutta/async/util/LruCache.java
+++ b/AndroidAsync/src/com/koushikdutta/async/util/LruCache.java
@@ -17,6 +17,7 @@
 package com.koushikdutta.async.util;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -321,7 +322,7 @@ public class LruCache<K, V> {
     @Override public synchronized final String toString() {
         int accesses = hitCount + missCount;
         int hitPercent = accesses != 0 ? (100 * hitCount / accesses) : 0;
-        return String.format("LruCache[maxSize=%d,hits=%d,misses=%d,hitRate=%d%%]",
+        return String.format(Locale.US, "LruCache[maxSize=%d,hits=%d,misses=%d,hitRate=%d%%]",
                 maxSize, hitCount, missCount, hitPercent);
     }
 }


### PR DESCRIPTION
Added Locale.US to String.format() to fix the locale of requests.

Issue: Socket.io request is not recognized due to the strange transport header in emitRaw(). (same as mentioned in [issue 222](https://github.com/koush/AndroidAsync/issues/222)).