### PR TITLE
prevent ResponseCacheMiddleware spewInternal from crashing the process.

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
@@ -425,7 +425,12 @@ public class ResponseCacheMiddleware extends SimpleMiddleware {
 
         void spewInternal() {
             if (pending.remaining() > 0) {
-                super.onDataAvailable(CachedBodyEmitter.this, pending);
+                try{
+                    super.onDataAvailable(CachedBodyEmitter.this, pending);
+                }catch(RuntimeException e){
+                    pending.recycle();
+                    return;
+                }
                 if (pending.remaining() > 0)
                     return;
             }


### PR DESCRIPTION
Attempt to slap a bandaid on https://github.com/koush/AndroidAsync/issues/358