### PR TITLE
Websocket-extension changes to permessage-deflate

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/WebSocketImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/WebSocketImpl.java
@@ -146,7 +146,7 @@ public class WebSocketImpl implements WebSocket {
         final String key = Base64.encodeToString(toByteArray(UUID.randomUUID()),Base64.NO_WRAP);
         headers.set("Sec-WebSocket-Version", "13");
         headers.set("Sec-WebSocket-Key", key);
-        headers.set("Sec-WebSocket-Extensions", "x-webkit-deflate-frame");
+        headers.set("Sec-WebSocket-Extensions", "permessage-deflate");
         headers.set("Connection", "Upgrade");
         headers.set("Upgrade", "websocket");
         if (protocol != null)
@@ -183,7 +183,7 @@ public class WebSocketImpl implements WebSocket {
         String extensions = requestHeaders.get("Sec-WebSocket-Extensions");
         boolean deflate = false;
         if (extensions != null) {
-            if (extensions.equals("x-webkit-deflate-frame"))
+            if (extensions.equals("permessage-deflate"))
                 deflate = true;
             // is this right? do we want to crap out here? Commenting out
             // as I suspect this caused a regression.


### PR DESCRIPTION
I've made changes related to Sec-Websocket-Extension changed to permessage-deflate to for websocket connection establishment with the server running on Tomcat 8.0.23, because the support for "x-webkit-deflate-frame" is removed in this version and hence we couldn't connect to server.