### PR TITLE
Handle cases where the transport becomes null during the socketIO heartbeat

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -176,8 +176,11 @@ class SocketIOConnection {
             public void run() {
                 if (heartbeat <= 0 || ts != transport || ts == null || !ts.isConnected())
                     return;
+
                 transport.send("2:::");
-                transport.getServer().postDelayed(this, heartbeat);
+
+                if (transport != null)
+                    transport.getServer().postDelayed(this, heartbeat);
             }
         };
         heartbeatRunner.run();


### PR DESCRIPTION
This fixes issue https://github.com/koush/AndroidAsync/issues/295, A crash which I have been seeing in 5% of all sessions of my Android application using this library. During certain network conditions, the transport reference can become null during the "send" operation in the heartbeat. Simply checking for null afterwards prevents the crash.

