### PR TITLE
Enable TLS on api < lvl 20

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
@@ -47,6 +47,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
+import android.content.Context;
+
 public class AsyncHttpClient {
     private static AsyncHttpClient mDefaultInstance;
     public static AsyncHttpClient getDefaultInstance() {
@@ -62,6 +64,23 @@ public class AsyncHttpClient {
     }
     public void insertMiddleware(AsyncHttpClientMiddleware middleware) {
         mMiddleware.add(0, middleware);
+    }
+
+    //TLS 1.2 is only supported for SSLEngine in Lollipop (api lvl 20) and above
+    //If you want to use TLS 1.2 in old versions of Android, you need to update SSLEngine
+    //Inspired by thus post: http://www.dahuatu.com/bawYXMDjmQ.html
+
+    public void enableSSLProtocolOnOlderVersionsOfAndroid(Context context, String procotol) throws GooglePlayServicesNotAvailableException, GooglePlayServicesRepairableException {
+        //Get the a more recent security provider using google play services
+        //Will raise exceptions if device doesn't have proper google play services installed
+        ProviderInstaller.installIfNeeded(context);
+
+        //Example: set protocol to "TLSv1.2" for TLS 1.2
+        SSLContext sslContext = SSLContext.getInstance(procotol);
+
+        //Create new SSL Engine and insert it as middlewear
+        SSLEngine engine = sslContext.createSSLEngine();
+        insertMiddleware((AsyncHttpClientMiddleware) engine);
     }
 
     SpdyMiddleware sslSocketMiddleware;
@@ -505,7 +524,7 @@ public class AsyncHttpClient {
 
     public static abstract class JSONObjectCallback extends RequestCallbackBase<JSONObject> {
     }
-    
+
     public static abstract class JSONArrayCallback extends RequestCallbackBase<JSONArray> {
     }
 

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
@@ -70,13 +70,13 @@ public class AsyncHttpClient {
     //If you want to use TLS 1.2 in old versions of Android, you need to update SSLEngine
     //Inspired by thus post: http://www.dahuatu.com/bawYXMDjmQ.html
 
-    public void enableSSLProtocolOnOlderVersionsOfAndroid(Context context, String procotol) throws GooglePlayServicesNotAvailableException, GooglePlayServicesRepairableException {
+    public void enableTLSProtocolOnOlderVersionsOfAndroid(Context context, String protocol) throws GooglePlayServicesNotAvailableException, GooglePlayServicesRepairableException {
         //Get the a more recent security provider using google play services
         //Will raise exceptions if device doesn't have proper google play services installed
         ProviderInstaller.installIfNeeded(context);
 
         //Example: set protocol to "TLSv1.2" for TLS 1.2
-        SSLContext sslContext = SSLContext.getInstance(procotol);
+        SSLContext sslContext = SSLContext.getInstance(protocol);
 
         //Create new SSL Engine and insert it as middlewear
         SSLEngine engine = sslContext.createSSLEngine();


### PR DESCRIPTION
[SSLEngine](http://developer.android.com/reference/javax/net/ssl/SSLEngine.html) only supports TLS 1.1 and 1.2 on android API lvl 20 or greater.

`enableTLSProtocolOnOlderVersionsOfAndroid(Context context, String protocol)` 
lets the user set a protocol (ex: "TLSv1.2") and update the SSLEngine that AndroidAsync is using to permit older versions of Android to use TLS.

I tested it on API lvl 16 at the lowest, I am unsure if it works for versions below that.
