### PR TITLE
handle custom hostname verifyer result

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncSSLSocketWrapper.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncSSLSocketWrapper.java
@@ -302,7 +302,9 @@ public class AsyncSSLSocketWrapper implements AsyncSocketWrapper, AsyncSSLSocket
                                     verifier.verify(mHost, StrictHostnameVerifier.getCNs(peerCertificates[0]), StrictHostnameVerifier.getDNSSubjectAlts(peerCertificates[0]));
                                 }
                                 else {
-                                    hostnameVerifier.verify(mHost, engine.getSession());
+                                    if (!hostnameVerifier.verify(mHost, engine.getSession())) {
+                                        throw new SSLException("hostname <" + mHost + "> has been denied");
+                                    }
                                 }
                             }
                             trusted = true;


### PR DESCRIPTION
When using a custom hostnameVerifier verify() is executed but its return value was not taken into account. This method does not throw SSLException so the verification had no effect.
I changed this to throw a SSLException if verify() returns false.