### PR TITLE
Reset selection key to read state on each write callback call

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncNetworkSocket.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncNetworkSocket.java
@@ -48,6 +48,7 @@ public class AsyncNetworkSocket implements AsyncSocket {
     
     public void onDataWritable() {
 //        assert mWriteableHandler != null;
+        mKey.interestOps(SelectionKey.OP_READ);
         if (mWriteableHandler != null)
             mWriteableHandler.onWriteable();
     }


### PR DESCRIPTION
Fixes io loop spin when writable callback becomes null (see #391)