### PR TITLE
set Locale.ENGLISH to all format related functions

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpRequest.java
@@ -6,6 +6,8 @@ import android.util.Log;
 import com.koushikdutta.async.AsyncSSLException;
 import com.koushikdutta.async.http.body.AsyncHttpRequestBody;
 
+import java.util.Locale;
+
 public class AsyncHttpRequest {
     public RequestLine getRequestLine() {
         return new RequestLine() {
@@ -27,7 +29,7 @@ public class AsyncHttpRequest {
             @Override
             public String toString() {
                 if (proxyHost != null)
-                    return String.format("%s %s HTTP/1.1", mMethod, AsyncHttpRequest.this.getUri());
+                    return String.format(Locale.ENGLISH, "%s %s HTTP/1.1", mMethod, AsyncHttpRequest.this.getUri());
                 String path = AsyncHttpRequest.this.getUri().getEncodedPath();
                 if (path == null || path.length() == 0)
                     path = "/";
@@ -35,7 +37,7 @@ public class AsyncHttpRequest {
                 if (query != null && query.length() != 0) {
                     path += "?" + query;
                 }
-                return String.format("%s %s HTTP/1.1", mMethod, path);
+                return String.format(Locale.ENGLISH, "%s %s HTTP/1.1", mMethod, path);
             }
         };
     }
@@ -187,7 +189,7 @@ public class AsyncHttpRequest {
             elapsed = System.currentTimeMillis() - executionTime;
         else
             elapsed = 0;
-        return String.format("(%d ms) %s: %s", elapsed, getUri(), message);
+        return String.format(Locale.ENGLISH, "(%d ms) %s: %s", elapsed, getUri(), message);
     }
     public void logi(String message) {
         if (LOGTAG == null)

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
@@ -14,6 +14,7 @@ import com.koushikdutta.async.callback.ConnectCallback;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -102,7 +103,7 @@ public class AsyncSSLSocketMiddleware extends AsyncSocketMiddleware {
                 // this SSL connection is proxied, must issue a CONNECT request to the proxy server
                 // http://stackoverflow.com/a/6594880/704837
                 // some proxies also require 'Host' header, it should be safe to provide it every time
-                String connect = String.format("CONNECT %s:%s HTTP/1.1\r\nHost: %s\r\n\r\n", uri.getHost(), port, uri.getHost());
+                String connect = String.format(Locale.ENGLISH, "CONNECT %s:%s HTTP/1.1\r\nHost: %s\r\n\r\n", uri.getHost(), port, uri.getHost());
                 data.request.logv("Proxying: " + connect);
                 Util.writeAll(socket, connect.getBytes(), new CompletedCallback() {
                     @Override

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSocketMiddleware.java
@@ -18,6 +18,7 @@ import com.koushikdutta.async.future.TransformFuture;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Hashtable;
+import java.util.Locale;
 
 public class AsyncSocketMiddleware extends SimpleMiddleware {
     String scheme;
@@ -213,7 +214,7 @@ public class AsyncSocketMiddleware extends SimpleMiddleware {
                 });
 
                 for (final InetAddress address: result) {
-                    final String inetSockAddress = String.format("%s:%s", address, port);
+                    final String inetSockAddress = String.format(Locale.ENGLISH, "%s:%s", address, port);
                     keepTrying.add(new ContinuationCallback() {
                         @Override
                         public void onContinue(Continuation continuation, final CompletedCallback next) throws Exception {

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/Part.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/Part.java
@@ -9,6 +9,7 @@ import org.apache.http.NameValuePair;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 
 public class Part {
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
@@ -28,10 +29,10 @@ public class Part {
     public Part(String name, long length, List<NameValuePair> contentDisposition) {
         this.length = length;
         mHeaders = new Headers();
-        StringBuilder builder = new StringBuilder(String.format("form-data; name=\"%s\"", name));
+        StringBuilder builder = new StringBuilder(String.format(Locale.ENGLISH, "form-data; name=\"%s\"", name));
         if (contentDisposition != null) {
             for (NameValuePair pair: contentDisposition) {
-                builder.append(String.format("; %s=\"%s\"", pair.getName(), pair.getValue()));
+                builder.append(String.format(Locale.ENGLISH, "; %s=\"%s\"", pair.getName(), pair.getValue()));
             }
         }
         mHeaders.set(CONTENT_DISPOSITION, builder.toString());

--- a/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/cache/ResponseCacheMiddleware.java
@@ -43,6 +43,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import javax.net.ssl.SSLEngine;
@@ -226,7 +227,7 @@ public class ResponseCacheMiddleware extends SimpleMiddleware {
         CacheData cacheData = data.state.get("cache-data");
         RawHeaders rh = RawHeaders.fromMultimap(data.response.headers().getMultiMap());
         rh.removeAll("Content-Length");
-        rh.setStatusLine(String.format("%s %s %s", data.response.protocol(), data.response.code(), data.response.message()));
+        rh.setStatusLine(String.format(Locale.ENGLISH, "%s %s %s", data.response.protocol(), data.response.code(), data.response.message()));
         ResponseHeaders networkResponse = new ResponseHeaders(data.request.getUri(), rh);
         data.state.put("response-headers", networkResponse);
         if (cacheData != null) {

--- a/AndroidAsync/src/com/koushikdutta/async/http/filter/GZIPInputFilter.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/filter/GZIPInputFilter.java
@@ -9,6 +9,7 @@ import com.koushikdutta.async.callback.DataCallback;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Locale;
 import java.util.zip.CRC32;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.Inflater;
@@ -55,7 +56,7 @@ public class GZIPInputFilter extends InflaterInputFilter {
                 public void parsed(byte[] header) {
                     short magic = peekShort(header, 0, ByteOrder.LITTLE_ENDIAN);
                     if (magic != (short) GZIPInputStream.GZIP_MAGIC) {
-                        report(new IOException(String.format("unknown format (magic number %x)", magic)));
+                        report(new IOException(String.format(Locale.ENGLISH, "unknown format (magic number %x)", magic)));
                         emitter.setDataCallback(new NullDataCallback());
                         return;
                     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServerResponseImpl.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServerResponseImpl.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Locale;
 
 public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
     private Headers mRawHeaders = new Headers();
@@ -96,7 +97,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
             isChunked = false;
         }
 
-        String statusLine = String.format("HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
+        String statusLine = String.format(Locale.ENGLISH, "HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
         String rh = mRawHeaders.toPrefixString(statusLine);
 
         Util.writeAll(mSocket, rh.getBytes(), new CompletedCallback() {
@@ -270,7 +271,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
                     end = totalLength - 1;
 
                 code(206);
-                getHeaders().set("Content-Range", String.format("bytes %d-%d/%d", start, end, totalLength));
+                getHeaders().set("Content-Range", String.format(Locale.ENGLISH, "bytes %d-%d/%d", start, end, totalLength));
             }
             catch (Exception e) {
                 code(416);
@@ -392,7 +393,7 @@ public class AsyncHttpServerResponseImpl implements AsyncHttpServerResponse {
     public String toString() {
         if (mRawHeaders == null)
             return super.toString();
-        String statusLine = String.format("HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
+        String statusLine = String.format(Locale.ENGLISH, "HTTP/1.1 %s %s", code, AsyncHttpServer.getResponseCodeDescription(code));
         return mRawHeaders.toPrefixString(statusLine);
     }
 }

--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.future.Cancellable;
 import com.koushikdutta.async.future.DependentCancellable;
-import com.koushikdutta.async.future.Future;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.async.future.SimpleFuture;
 import com.koushikdutta.async.future.TransformFuture;
@@ -23,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Locale;
 
 /**
  * Created by koush on 7/1/13.
@@ -54,13 +54,13 @@ class SocketIOConnection {
             ack =  id + "+";
             acknowledges.put(id, acknowledge);
         }
-        transport.send(String.format("%d:%s:%s:%s", type, ack, client.endpoint, message));
+        transport.send(String.format(Locale.ENGLISH, "%d:%s:%s:%s", type, ack, client.endpoint, message));
     }
 
     public void connect(SocketIOClient client) {
         if (!clients.contains(client))
             clients.add(client);
-        transport.send(String.format("1::%s", client.endpoint));
+        transport.send(String.format(Locale.ENGLISH, "1::%s", client.endpoint));
     }
 
     public void disconnect(SocketIOClient client) {
@@ -79,7 +79,7 @@ class SocketIOConnection {
         }
 
         if (needsEndpointDisconnect && transport != null)
-            transport.send(String.format("0::%s", client.endpoint));
+            transport.send(String.format(Locale.ENGLISH, "0::%s", client.endpoint));
 
         // and see if we can disconnect the socket completely
         if (clients.size() > 0 || transport == null)
@@ -360,7 +360,7 @@ class SocketIOConnection {
                     });
                     return;
                 }
-                transport.send(String.format("6:::%s%s", messageId, data));
+                transport.send(String.format(Locale.ENGLISH, "6:::%s%s", messageId, data));
             }
         };
     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/BitArray.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/BitArray.java
@@ -18,6 +18,7 @@ package com.koushikdutta.async.http.spdy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import static java.lang.String.format;
 
@@ -68,7 +69,7 @@ interface BitArray {
 
     private static int checkInput(int index) {
       if (index < 0 || index > 63) {
-        throw new IllegalArgumentException(format("input must be between 0 and 63: %s", index));
+        throw new IllegalArgumentException(format(Locale.ENGLISH, "input must be between 0 and 63: %s", index));
       }
       return index;
     }
@@ -169,7 +170,7 @@ interface BitArray {
 
     private static int checkInput(int index) {
       if (index < 0) {
-        throw new IllegalArgumentException(format("input must be a positive number: %s", index));
+        throw new IllegalArgumentException(format(Locale.ENGLISH, "input must be a positive number: %s", index));
       }
       return index;
     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/ByteString.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/ByteString.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Field;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * An immutable sequence of bytes.
@@ -253,11 +254,11 @@ final class ByteString implements Serializable {
     }
 
     if (data.length <= 16) {
-      return String.format("ByteString[size=%s data=%s]", data.length, hex());
+      return String.format(Locale.ENGLISH, "ByteString[size=%s data=%s]", data.length, hex());
     }
 
     try {
-      return String.format("ByteString[size=%s md5=%s]", data.length,
+      return String.format(Locale.ENGLISH, "ByteString[size=%s md5=%s]", data.length,
           ByteString.of(MessageDigest.getInstance("MD5").digest(data)).hex());
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError();

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/Header.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/Header.java
@@ -1,6 +1,8 @@
 package com.koushikdutta.async.http.spdy;
 
 
+import java.util.Locale;
+
 /** HTTP header: the name is an ASCII string, but the value can be UTF-8. */
 final class Header {
   // Special header names defined in the SPDY and HTTP/2 specs.
@@ -50,6 +52,6 @@ final class Header {
   }
 
   @Override public String toString() {
-    return String.format("%s: %s", name.utf8(), value.utf8());
+    return String.format(Locale.ENGLISH, "%s: %s", name.utf8(), value.utf8());
   }
 }

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/Http20Draft13.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/Http20Draft13.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import static com.koushikdutta.async.http.spdy.Http20Draft13.FrameLogger.formatHeader;
@@ -431,7 +432,7 @@ final class Http20Draft13 implements Variant {
             if (closed) throw new IOException("closed");
             if (!client) return; // Nothing to write; servers don't send connection headers!
             if (logger.isLoggable(FINE)) {
-                logger.fine(format(">> CONNECTION %s", CONNECTION_PREFACE.hex()));
+                logger.fine(format(Locale.ENGLISH, ">> CONNECTION %s", CONNECTION_PREFACE.hex()));
             }
             sink.write(new ByteBufferList(CONNECTION_PREFACE.toByteArray()));
         }
@@ -632,11 +633,11 @@ final class Http20Draft13 implements Variant {
     }
 
     private static IllegalArgumentException illegalArgument(String message, Object... args) {
-        throw new IllegalArgumentException(format(message, args));
+        throw new IllegalArgumentException(format(Locale.ENGLISH, message, args));
     }
 
     private static IOException ioException(String message, Object... args) throws IOException {
-        throw new IOException(format(message, args));
+        throw new IOException(format(Locale.ENGLISH, message, args));
     }
 
     private static short lengthWithoutPadding(short length, byte flags, short padding)
@@ -669,9 +670,9 @@ final class Http20Draft13 implements Variant {
     static final class FrameLogger {
 
         static String formatHeader(boolean inbound, int streamId, int length, byte type, byte flags) {
-            String formattedType = type < TYPES.length ? TYPES[type] : format("0x%02x", type);
+            String formattedType = type < TYPES.length ? TYPES[type] : format(Locale.ENGLISH, "0x%02x", type);
             String formattedFlags = formatFlags(type, flags);
-            return format("%s 0x%08x %5d %-13s %s", inbound ? "<<" : ">>", streamId, length,
+            return format(Locale.ENGLISH, "%s 0x%08x %5d %-13s %s", inbound ? "<<" : ">>", streamId, length,
             formattedType, formattedFlags);
         }
 
@@ -727,7 +728,7 @@ final class Http20Draft13 implements Variant {
 
         static {
             for (int i = 0; i < BINARY.length; i++) {
-                BINARY[i] = format("%8s", Integer.toBinaryString(i)).replace(' ', '0');
+                BINARY[i] = format(Locale.ENGLISH, "%8s", Integer.toBinaryString(i)).replace(' ', '0');
             }
 
             FLAGS[FLAG_NONE] = "";

--- a/AndroidAsync/src/com/koushikdutta/async/http/spdy/Spdy3.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/spdy/Spdy3.java
@@ -30,6 +30,7 @@ import java.net.ProtocolException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.Deflater;
 
 
@@ -351,7 +352,7 @@ final class Spdy3 implements Variant {
         }
 
         private static IOException ioException(String message, Object... args) throws IOException {
-            throw new IOException(String.format(message, args));
+            throw new IOException(String.format(Locale.ENGLISH, message, args));
         }
     }
 

--- a/AndroidAsync/src/com/koushikdutta/async/util/LruCache.java
+++ b/AndroidAsync/src/com/koushikdutta/async/util/LruCache.java
@@ -17,6 +17,7 @@
 package com.koushikdutta.async.util;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -321,7 +322,7 @@ public class LruCache<K, V> {
     @Override public synchronized final String toString() {
         int accesses = hitCount + missCount;
         int hitPercent = accesses != 0 ? (100 * hitCount / accesses) : 0;
-        return String.format("LruCache[maxSize=%d,hits=%d,misses=%d,hitRate=%d%%]",
+        return String.format(Locale.ENGLISH, "LruCache[maxSize=%d,hits=%d,misses=%d,hitRate=%d%%]",
                 maxSize, hitCount, missCount, hitPercent);
     }
 }


### PR DESCRIPTION
This is fix for AndroidAsync does not work when running properly, when it runs on system with Locale which prefer non English numeric. This non english numeric locale even applied String.format("%d", 1);
