### PR TITLE
fix AndroidAsync NameValuePair class defining a duplicate org.apache.http.NameValuePair

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/BasicNameValuePair.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/BasicNameValuePair.java
@@ -33,8 +33,6 @@ package com.koushikdutta.async.http;
 
 import android.text.TextUtils;
 
-import org.apache.http.NameValuePair;
-
 /**
  * A simple class encapsulating an attribute/value pair.
  * <p>

--- a/AndroidAsync/src/com/koushikdutta/async/http/Multimap.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/Multimap.java
@@ -2,8 +2,6 @@ package com.koushikdutta.async.http;
 
 import android.net.Uri;
 
-import org.apache.http.NameValuePair;
-
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/AndroidAsync/src/com/koushikdutta/async/http/NameValuePair.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/NameValuePair.java
@@ -29,7 +29,7 @@
  *
  */
 
-package org.apache.http;
+package com.koushikdutta.async.http;
 
 /**
  * A simple class encapsulating an attribute/value pair.

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/FilePart.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/FilePart.java
@@ -1,8 +1,7 @@
 package com.koushikdutta.async.http.body;
 
 import com.koushikdutta.async.http.BasicNameValuePair;
-
-import org.apache.http.NameValuePair;
+import com.koushikdutta.async.http.NameValuePair;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,7 +18,7 @@ public class FilePart extends StreamPart {
             }
         });
 
-//        getRawHeaders().set("Content-Type", "application/xml");
+//        getRawHeaders().setString("Content-Type", "application/xml");
 
         this.file = file;
     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/FilePart.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/FilePart.java
@@ -18,7 +18,7 @@ public class FilePart extends StreamPart {
             }
         });
 
-//        getRawHeaders().setString("Content-Type", "application/xml");
+//        getRawHeaders().set("Content-Type", "application/xml");
 
         this.file = file;
     }

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/Part.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/Part.java
@@ -4,8 +4,7 @@ import com.koushikdutta.async.DataSink;
 import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.http.Headers;
 import com.koushikdutta.async.http.Multimap;
-
-import org.apache.http.NameValuePair;
+import com.koushikdutta.async.http.NameValuePair;
 
 import java.io.File;
 import java.util.List;

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/StreamPart.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/StreamPart.java
@@ -4,10 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
-import org.apache.http.NameValuePair;
-
 import com.koushikdutta.async.DataSink;
 import com.koushikdutta.async.callback.CompletedCallback;
+import com.koushikdutta.async.http.NameValuePair;
 
 public abstract class StreamPart extends Part {
     public StreamPart(String name, long length, List<NameValuePair> contentDisposition) {

--- a/AndroidAsync/src/com/koushikdutta/async/http/body/UrlEncodedFormBody.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/body/UrlEncodedFormBody.java
@@ -8,9 +8,8 @@ import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.callback.DataCallback;
 import com.koushikdutta.async.http.AsyncHttpRequest;
 import com.koushikdutta.async.http.Multimap;
+import com.koushikdutta.async.http.NameValuePair;
 import com.koushikdutta.async.util.Charsets;
-
-import org.apache.http.NameValuePair;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;


### PR DESCRIPTION
This causes warning in Proguard with duplicate class notifications. Also causes ClassCastExceptions during runtime.