### PR TITLE
Avoid npe in SocketIOConnection

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -6,7 +6,6 @@ import android.text.TextUtils;
 import com.koushikdutta.async.callback.CompletedCallback;
 import com.koushikdutta.async.future.Cancellable;
 import com.koushikdutta.async.future.DependentCancellable;
-import com.koushikdutta.async.future.Future;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.async.future.SimpleFuture;
 import com.koushikdutta.async.future.TransformFuture;
@@ -32,6 +31,7 @@ class SocketIOConnection {
     int heartbeat;
     long reconnectDelay;
     ArrayList<SocketIOClient> clients = new ArrayList<SocketIOClient>();
+
     SocketIOTransport transport;
     SocketIORequest request;
 
@@ -170,19 +170,19 @@ class SocketIOConnection {
     }
 
     void setupHeartbeat() {
-        final SocketIOTransport ts = transport;
         Runnable heartbeatRunner = new Runnable() {
             @Override
             public void run() {
-                if (heartbeat <= 0 || ts != transport || ts == null || !ts.isConnected())
+                final SocketIOTransport ts = transport;
+
+                if (heartbeat <= 0 || ts == null || !ts.isConnected())
                     return;
 
-                transport.send("2:::");
-
-                if (transport != null)
-                    transport.getServer().postDelayed(this, heartbeat);
+                ts.send("2:::");
+                ts.getServer().postDelayed(this, heartbeat);
             }
         };
+
         heartbeatRunner.run();
     }
 


### PR DESCRIPTION
I have seen many crashes in the wild with this stack trace:

java.lang.NullPointerException: Attempt to invoke interface method 'com.koushikdutta.async.AsyncServer com.koushikdutta.async.http.socketio.transport.SocketIOTransport.getServer()' on a null object reference
at com.koushikdutta.async.http.socketio.SocketIOConnection$3.run (SocketIOConnection.java:180)
at com.koushikdutta.async.AsyncServer.lockAndRunQueue (AsyncServer.java:708)
at com.koushikdutta.async.AsyncServer.runLoop (AsyncServer.java:725)
at com.koushikdutta.async.AsyncServer.run (AsyncServer.java:626)
at com.koushikdutta.async.AsyncServer.access$700 (AsyncServer.java:41)
at com.koushikdutta.async.AsyncServer$13.run (AsyncServer.java:568)