### PR TITLE
Fix leak in HybiParser

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/HybiParser.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/HybiParser.java
@@ -64,9 +64,8 @@ abstract class HybiParser {
 
     private boolean mClosed = false;
 
-    private ByteArrayOutputStream mBuffer = new ByteArrayOutputStream();
-    private Inflater mInflater = new Inflater(true);
-    private byte[] mInflateBuffer = new byte[4096];
+    private final ByteArrayOutputStream mBuffer = new ByteArrayOutputStream();
+    private final byte[] mInflateBuffer = new byte[4096];
 
     private static final int BYTE   = 255;
     private static final int FIN    = 128;
@@ -116,19 +115,26 @@ abstract class HybiParser {
     private byte[] inflate(byte[] payload) throws DataFormatException {
         ByteArrayOutputStream inflated = new ByteArrayOutputStream();
 
-        mInflater.setInput(payload);
-        while (!mInflater.needsInput()) {
-            int chunkSize = mInflater.inflate(mInflateBuffer);
+        Inflater inflater = new Inflater(true);
+        inflater.setInput(payload);
+
+        while (!inflater.needsInput()) {
+            int chunkSize = inflater.inflate(mInflateBuffer);
             inflated.write(mInflateBuffer, 0, chunkSize);
         }
 
-        mInflater.setInput(new byte[] { 0, 0, -1, -1 });
-        while (!mInflater.needsInput()) {
-            int chunkSize = mInflater.inflate(mInflateBuffer);
+        inflater.setInput(new byte[] { 0, 0, -1, -1 });
+
+        while (!inflater.needsInput()) {
+            int chunkSize = inflater.inflate(mInflateBuffer);
             inflated.write(mInflateBuffer, 0, chunkSize);
         }
 
-        return inflated.toByteArray();
+        try {
+            return inflated.toByteArray();
+        } finally {
+            inflater.end();
+        }
     }
 
     public void setMasking(boolean masking) {
@@ -152,7 +158,7 @@ abstract class HybiParser {
             parse();
         }
     };
-    
+
     DataCallback mStage1 = new DataCallback() {
         @Override
         public void onDataAvailable(DataEmitter emitter, ByteBufferList bb) {
@@ -160,7 +166,7 @@ abstract class HybiParser {
             parse();
         }
     };
-    
+
     DataCallback mStage2 = new DataCallback() {
         @Override
         public void onDataAvailable(DataEmitter emitter, ByteBufferList bb) {
@@ -176,7 +182,7 @@ abstract class HybiParser {
             parse();
         }
     };
-    
+
     DataCallback mStage3 = new DataCallback() {
         @Override
         public void onDataAvailable(DataEmitter emitter, ByteBufferList bb) {
@@ -204,7 +210,7 @@ abstract class HybiParser {
             parse();
         }
     };
-    
+
     void parse() {
         switch (mStage) {
         case 0:
@@ -224,7 +230,7 @@ abstract class HybiParser {
             break;
         }
     }
-    
+
     private DataEmitterReader mReader = new DataEmitterReader();
 
 	private static final long BASE = 2;
@@ -297,7 +303,7 @@ abstract class HybiParser {
     public byte[] frame(byte[] data) {
         return frame(OP_BINARY, data, -1);
     }
-    
+
     public byte[] frame(byte[] data, int offset, int length) {
     	return frame(OP_BINARY, data, -1, offset, length);
     }
@@ -308,7 +314,7 @@ abstract class HybiParser {
 
     /**
      * Flip the opcode so to avoid the name collision with the public method
-     * 
+     *
      * @param opcode
      * @param data
      * @param errorCode
@@ -320,7 +326,7 @@ abstract class HybiParser {
 
     /**
      * Don't actually need the flipped method signature, trying to keep it in line with the byte[] version
-     * 
+     *
      * @param opcode
      * @param data
      * @param errorCode
@@ -329,7 +335,7 @@ abstract class HybiParser {
     private byte[] frame(int opcode, String data, int errorCode) {
         return frame(opcode, decode(data), errorCode);
     }
-    
+
     private byte[] frame(int opcode, byte [] data, int errorCode, int dataOffset, int dataLength) {
         if (mClosed) return null;
 
@@ -351,7 +357,7 @@ abstract class HybiParser {
             frame[2] = (byte) (length / 256);
             frame[3] = (byte) (length & BYTE);
         } else {
-        	
+
         	frame[1] = (byte) (masked | 127);
             frame[2] = (byte) (( length / _2_TO_56_) & BYTE);
             frame[3] = (byte) (( length / _2_TO_48_) & BYTE);
@@ -367,7 +373,7 @@ abstract class HybiParser {
             frame[offset] = (byte) ((errorCode / 256) & BYTE);
             frame[offset+1] = (byte) (errorCode & BYTE);
         }
-        
+
         System.arraycopy(buffer, dataOffset, frame, offset + insert, dataLength - dataOffset);
 
         if (mMasking) {
@@ -449,7 +455,7 @@ abstract class HybiParser {
 //            Log.d(TAG, "Got pong! " + message);
         }
     }
-    
+
     protected abstract void onMessage(byte[] payload);
     protected abstract void onMessage(String payload);
     protected abstract void onPong(String payload);


### PR DESCRIPTION
In strict mode, was getting warning:

java.lang.Throwable: Explicit termination method 'end' not called
   at dalvik.system.CloseGuard.open(CloseGuard.java:184)
   at java.util.zip.Inflater.<init>(Inflater.java:82)