### PR TITLE
Fix get incorrectly handling null bytes

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/ByteBufferList.java
+++ b/AndroidAsync/src/com/koushikdutta/async/ByteBufferList.java
@@ -162,8 +162,12 @@ public class ByteBufferList {
         while (need > 0) {
             ByteBuffer b = mBuffers.peek();
             int read = Math.min(b.remaining(), need);
-            if (bytes != null)
+            if (bytes != null){
                 b.get(bytes, offset, read);
+            } else {
+                //when bytes is null, just skip data.
+                b.position(b.position() + read);
+            }
             need -= read;
             offset += read;
             if (b.remaining() == 0) {


### PR DESCRIPTION
When get(byte[], int, int) is called with null as the first parameter, it doesn't move the buffer pointer as expected. This issue breaks skip(int).

This pull request fixes #418