### PR TITLE
Avoid npe in SocketIOConnection

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/socketio/SocketIOConnection.java
@@ -79,16 +79,18 @@ class SocketIOConnection {
             }
         }
 
-        if (needsEndpointDisconnect && transport != null)
-            transport.send(String.format(Locale.ENGLISH, "0::%s", client.endpoint));
+        final SocketIOTransport ts = transport;
+
+        if (needsEndpointDisconnect && ts != null)
+            ts.send(String.format(Locale.ENGLISH, "0::%s", client.endpoint));
 
         // and see if we can disconnect the socket completely
-        if (clients.size() > 0 || transport == null)
+        if (clients.size() > 0 || ts == null)
             return;
 
-        transport.setStringCallback(null);
-        transport.setClosedCallback(null);
-        transport.disconnect();
+        ts.setStringCallback(null);
+        ts.setClosedCallback(null);
+        ts.disconnect();
         transport = null;
     }
 


### PR DESCRIPTION
- Seeing crashes in the wild, due to threading issues (transport can be mutated on any thread)

- java.lang.NullPointerException: Attempt to invoke interface method
  'void com.koushikdutta.async.http.socketio.transport.SocketIOTransport.setClosedCallback(
   com.koushikdutta.async.callback.CompletedCallback)' on a null object reference

   at com.koushikdutta.async.http.socketio.SocketIOConnection.disconnect (SocketIOConnection.java:89)
   at com.koushikdutta.async.http.socketio.SocketIOClient.disconnect (SocketIOClient.java:170)