### PR TITLE
Remove SSLEngineSNIConfigurator

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncHttpClient.java
@@ -74,7 +74,6 @@ public class AsyncHttpClient {
         insertMiddleware(socketMiddleware = new AsyncSocketMiddleware(this));
         insertMiddleware(sslSocketMiddleware = new SpdyMiddleware(this));
         insertMiddleware(httpTransportMiddleware = new HttpTransportMiddleware());
-        sslSocketMiddleware.addEngineConfigurator(new SSLEngineSNIConfigurator());
     }
 
     @SuppressLint("NewApi")

--- a/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/AsyncSSLSocketMiddleware.java
@@ -60,7 +60,7 @@ public class AsyncSSLSocketMiddleware extends AsyncSocketMiddleware {
 
     protected SSLEngine createConfiguredSSLEngine(GetSocketData data, String host, int port) {
         SSLContext sslContext = getSSLContext();
-        SSLEngine sslEngine = sslContext.createSSLEngine();
+        SSLEngine sslEngine = sslContext.createSSLEngine(host, port);
 
         for (AsyncSSLEngineConfigurator configurator : engineConfigurators) {
             configurator.configureEngine(sslEngine, data, host, port);


### PR DESCRIPTION
https://github.com/koush/AndroidAsync/issues/537

I don't know if this fix is entirely correct, but it works for me with Google Play Services 9.4.52 and the latest 11.0.55.

I have not changed anything to the SpdyMiddleware, so that still is using reflection (and fails).