### PR TITLE
Content Length Long

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/HttpUtil.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/HttpUtil.java
@@ -132,12 +132,12 @@ public class HttpUtil {
         return "keep-alive".equalsIgnoreCase(connection);
     }
 
-    public static int contentLength(Headers headers) {
+    public static long contentLength(Headers headers) {
         String cl = headers.get("Content-Length");
         if (cl == null)
             return -1;
         try {
-            return Integer.parseInt(cl);
+            return Long.parseLong(cl);
         }
         catch (NumberFormatException e) {
             return -1;


### PR DESCRIPTION
HttpsUtil contentLength currently returns an int
This updates this to parse and return a long instead.