### PR TITLE
Update AsyncNetworkSocket.java

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/AsyncNetworkSocket.java
+++ b/AndroidAsync/src/com/koushikdutta/async/AsyncNetworkSocket.java
@@ -84,11 +84,16 @@ public class AsyncNetworkSocket implements AsyncSocket {
         }
 
         try {
+            
             int before = list.remaining();
-            ByteBuffer[] arr = list.getAllArray();
-            mChannel.write(arr);
-            list.addAll(arr);
-            handleRemaining(list.remaining());
+            int remaining = before;
+            while (remaining > 0) { // busy wait or the socket will timeout with messages > 345kB
+                ByteBuffer[] arr = list.getAllArray();
+                mChannel.write(arr);
+                list.addAll(arr);
+                handleRemaining(list.remaining());
+                remaining = list.remaining();
+            }
             mServer.onDataSent(before - list.remaining());
         }
         catch (IOException e) {


### PR DESCRIPTION
There i a problem when a large (>345 kB) message is being written to a websocket. The connection will actually time out, unless this while is in place. Unfortunately, this pretty much busy-waits. But whatever the queueing mechanism is is broken at least for websockets and large messages. My messages are ~2MB. 

    .154 AndroidAsync: before:1926139
    .154 AndroidAsync: remaining:1577171
    .156 AndroidAsync: before:1926139
    .156 AndroidAsync: remaining:1577171
    AndroidAsync: before:1926139
    ...
    .240 AndroidAsync: remaining:0