### PR TITLE
handle url decode exceptions

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
@@ -108,7 +108,13 @@ public class AsyncHttpServer extends AsyncHttpServerRouter {
                     String statusLine = getStatusLine();
                     String[] parts = statusLine.split(" ");
                     fullPath = parts[1];
-                    path = URLDecoder.decode(fullPath.split("\\?")[0]);
+                    try {
+                        path = URLDecoder.decode(fullPath.split("\\?")[0], "UTF-8");
+                    } catch (Exception x) {
+                        Log.w("AsyncHttpServer", "Request for: " + fullPath + " failed: " +  x.getMessage());
+                        method = "";
+                        return null;
+                    }
                     method = parts[0];
                     RouteMatch route = route(method, path);
                     if (route == null)


### PR DESCRIPTION
If a url is requested that contains a `%` character the server will crash. 
This change will handle exceptions from UrlDecoder.

java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern
	at java.net.URLDecoder.decode(URLDecoder.java:196)
	at java.net.URLDecoder.decode(URLDecoder.java:101)
	at com.koushikdutta.async.http.server.AsyncHttpServer$1$1.onBody(AsyncHttpServer.java:111)
	at com.koushikdutta.async.http.server.AsyncHttpServerRequestImpl$2.onStringAvailable(AsyncHttpServerRequestImpl.java:83)
	at com.koushikdutta.async.LineEmitter.onDataAvailable(LineEmitter.java:42)
	at com.koushikdutta.async.Util.emitAllData(Util.java:23)
	at com.koushikdutta.async.AsyncSSLSocketWrapper.onDataAvailable(AsyncSSLSocketWrapper.java:335)
	at com.koushikdutta.async.AsyncSSLSocketWrapper$6.onDataAvailable(AsyncSSLSocketWrapper.java:322)
	at com.koushikdutta.async.Util.emitAllData(Util.java:23)
	at com.koushikdutta.async.AsyncNetworkSocket.onReadable(AsyncNetworkSocket.java:160)
	at com.koushikdutta.async.AsyncServer.runLoop(AsyncServer.java:878)
	at com.koushikdutta.async.AsyncServer.run(AsyncServer.java:726)
	at com.koushikdutta.async.AsyncServer.access$800(AsyncServer.java:46)
	at com.koushikdutta.async.AsyncServer$8.run(AsyncServer.java:680)