### PR TITLE
Add 401 and method to add more

### DIFF
--- a/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
+++ b/AndroidAsync/src/com/koushikdutta/async/http/server/AsyncHttpServer.java
@@ -330,6 +330,7 @@ public class AsyncHttpServer extends AsyncHttpServerRouter {
         mCodes.put(302, "Found");
         mCodes.put(304, "Not Modified");
         mCodes.put(400, "Bad Request");
+        mCodes.put(401, "Unauthorized");
         mCodes.put(404, "Not Found");
         mCodes.put(500, "Internal Server Error");
     }
@@ -339,6 +340,10 @@ public class AsyncHttpServer extends AsyncHttpServerRouter {
         if (d == null)
             return "Unknown";
         return d;
+    }
+
+    public static void addResponseCodeDescription( int code, String description ) {
+        mCodes.put(code, description);
     }
 
     public static interface WebSocketRequestCallback {


### PR DESCRIPTION
I was using Digest authentication and noticed that the `AsyncHttpServerResponse` returned `HTTP/1.1 401 Unknown` instead of `Unauthorized`. I added that code as well as a method to add custom codes should one need more.